### PR TITLE
No need to build for both linux-gnu and linux-musl

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
         command: sudo apt install -y clang gcc-mingw-w64-x86-64 llvm-4.0-dev musl-tools
     - run:
         name: install-rust-deps
-        command: rustup target add x86_64-apple-darwin && rustup target add x86_64-unknown-linux-gnu && rustup target add x86_64-unknown-linux-musl && rustup target add x86_64-pc-windows-gnu
+        command: rustup target add x86_64-apple-darwin && rustup target add x86_64-unknown-linux-musl && rustup target add x86_64-pc-windows-gnu
     - run:
         name: install osxcross-with-clang
         command: curl -O https://dark-osxcross-files.storage.googleapis.com/osxcross-with-clang.tar.gz && tar --strip-components=1 -xf osxcross-with-clang.tar.gz && rm osxcross-with-clang.tar.gz
@@ -63,7 +63,7 @@ jobs:
         - target/
     - run:
         name: prep-artifacts
-        command: mkdir artifacts && cp target/x86_64-apple-darwin/release/dark-cli artifacts/dark-cli-apple && cp target/x86_64-unknown-linux-gnu/release/dark-cli artifacts/dark-cli-linux-gnu && cp target/x86_64-unknown-linux-musl/release/dark-cli artifacts/dark-cli-linux-musl && cp target/x86_64-pc-windows-gnu/release/dark-cli.exe artifacts/dark-cli.exe
+        command: mkdir artifacts && cp target/x86_64-apple-darwin/release/dark-cli artifacts/dark-cli-apple && cp target/x86_64-unknown-linux-musl/release/dark-cli artifacts/dark-cli-linux && cp target/x86_64-pc-windows-gnu/release/dark-cli.exe artifacts/dark-cli.exe
     - store_artifacts:
         path:
           artifacts


### PR DESCRIPTION
linux-musl runs on ubuntu fine. It bumps the binary from 8.2M to 11M,
but also reduces our build time, and the # of binaries we offer to
develpers (reduces complexity).