### PR TITLE
Remove timeout so we can actually get to 100M (30s timeout on my laptop

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -234,7 +234,10 @@ fn main() -> Result<(), DarkError> {
 
     let (form, size) = form_body(&paths.to_string())?;
 
-    println!("Going to attempt to upload files totalling {}.", size.file_size(options::DECIMAL)?);
+    println!(
+        "Going to attempt to upload files totalling {}.",
+        size.file_size(options::DECIMAL)?
+    );
 
     let requri = format!("{}/api/{}/static_assets", host, canvas);
     let client = reqwest::Client::builder()


### PR DESCRIPTION
meant a cap of ~50M)

Also, modify the error msg to not mention that the upload cap is small.

also, tell the reqwest client to use gzip encoding.