### PR TITLE
Add success message when uploading assets

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -360,6 +360,7 @@ fn main() -> Result<(), DarkError> {
             .multipart(form)
             .send()
             .or_else(|error| Err(DarkError::Upload(error)))?;
+        println!("Upload succeeded!");
         println!("{}", resp.text()?);
     }
 


### PR DESCRIPTION
(Apparently some users get confused when there's no explicit message;
the json body with links wasn't enough.)

https://trello.com/c/hgy2mmie/2327-add-success-message-when-uploading-assets-via-dark-cli

Deliberately not bothering to bump the version; we'll wait to release until we've made changes needed for auth0.